### PR TITLE
Remove superfluous scrollbar

### DIFF
--- a/animportantdate/static/base.scss
+++ b/animportantdate/static/base.scss
@@ -56,7 +56,6 @@ body {
       > .container-fluid {
         list-style: none;
         margin: 0;
-        overflow: scroll;
         padding: 0;
         top: 0;
       }


### PR DESCRIPTION
I get scrollbars on the menu on Chrome on Linux. I'm probably not supposed to get scrollbars:

![image](https://user-images.githubusercontent.com/229984/28102640-6317dd28-6685-11e7-9fda-31e711233a3d.png)

This takes out the rule. It doesn't seem to affect anything else.