### PR TITLE
Added a Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,21 @@
+FROM oraclelinux:7-slim
+
+RUN yum-config-manager --enable ol7_software_collections --enable ol7_optional_latest && \
+    yum -y install gcc rh-python36 && \
+    rm -rf /var/cache/yum/*
+
+# Copy in the source
+COPY requirements/base.txt /requirements.txt 
+
+# Install build deps, then run `pip install`, then remove unneeded build deps all in a single step. 
+RUN scl enable rh-python36 -- pip install -r /requirements.txt
+
+COPY animportantdate/. /usr/src/app/
+WORKDIR /usr/src/app
+
+RUN scl enable rh-python36 -- python manage.py migrate
+
+EXPOSE 8000
+
+ENTRYPOINT ["scl", "enable", "rh-python36", "--"]
+CMD ["python", "manage.py", "runserver", "0.0.0.0:8000", "--insecure"]


### PR DESCRIPTION
Because Dockerfiles are cool. -- _Dr Who_.

_**"Hey Avi, why are you using Oracle Linux instead of the official Python image?"**_

That's a good question, random Internet person. It's because the resulting image when using Oracle Linux's nifty slim image is more than HALF the size of the official Python image (417MB vs 912MB).

_**"Why don't use use the Alpine version then?"**_

Because none of the requirements would compile, even after you install `gcc` and quite frankly, the yak started to complain about how much the shaving hurt at this point.

FYI, this image is likely incomplete, because I don't know where the actual database is stored and I'd like to persist that, if possible. However, the data at least survive restarts, if not deletes/recreates.

Signed-off-by: Avi Miller <me@dje.li>